### PR TITLE
Fix `A` and `AAAA` Record Resolution

### DIFF
--- a/main.go
+++ b/main.go
@@ -28,17 +28,14 @@ func Run(ctx context.Context, config string) error {
 
 	r := new(net.Resolver)
 	r.Dial = func(ctx context.Context, network, address string) (net.Conn, error) {
-	deadline, ok := ctx.Deadline()
-	if !ok {
+		deadline, ok := ctx.Deadline()
+		if !ok {
 			return nil, fmt.Errorf("deadline not set")
-	}
+		}
 
-	r := &net.Resolver{
-		PreferGo: true,
-		Dial: func(ctx context.Context, network, address string) (net.Conn, error) {
-			d := net.Dialer{
-				Deadline: deadline,
-			}
+		d := net.Dialer{
+			Deadline: deadline,
+		}
 
 		return d.DialContext(ctx, network, connStr)
 	}
@@ -52,7 +49,7 @@ func Run(ctx context.Context, config string) error {
 			return err
 		}
 
-		addresses := make([]string, len(ips))
+		addresses = make([]string, len(ips))
 		for i, ip := range ips {
 			addresses[i] = ip.String()
 		}
@@ -62,7 +59,7 @@ func Run(ctx context.Context, config string) error {
 			return err
 		}
 
-		addresses := make([]string, len(ips))
+		addresses = make([]string, len(ips))
 		for i, ip := range ips {
 			addresses[i] = ip.String()
 		}

--- a/main.go
+++ b/main.go
@@ -24,10 +24,13 @@ func Run(ctx context.Context, config string) error {
 		return err
 	}
 
-	connStr := fmt.Sprintf("%s:%d", schema.Target, schema.Port)
+	connStr := fmt.Sprintf("%s:%d", schema.Server, schema.Port)
+
+	r := new(net.Resolver)
+	r.Dial = func(ctx context.Context, network, address string) (net.Conn, error) {
 	deadline, ok := ctx.Deadline()
 	if !ok {
-		return fmt.Errorf("deadline not set")
+			return nil, fmt.Errorf("deadline not set")
 	}
 
 	r := &net.Resolver{
@@ -36,8 +39,8 @@ func Run(ctx context.Context, config string) error {
 			d := net.Dialer{
 				Deadline: deadline,
 			}
-			return d.DialContext(ctx, "udp", connStr)
-		},
+
+		return d.DialContext(ctx, network, connStr)
 	}
 
 	var addresses []string

--- a/main.go
+++ b/main.go
@@ -44,7 +44,7 @@ func Run(ctx context.Context, config string) error {
 
 	switch schema.Record {
 	case "A":
-		ips, err := r.LookupIP(ctx, "ipv4", schema.Domain)
+		ips, err := r.LookupIP(ctx, "ip4", schema.Domain)
 		if err != nil {
 			return err
 		}
@@ -54,7 +54,7 @@ func Run(ctx context.Context, config string) error {
 			addresses[i] = ip.String()
 		}
 	case "AAAA":
-		ips, err := r.LookupIP(ctx, "ipv6", schema.Domain)
+		ips, err := r.LookupIP(ctx, "ip6", schema.Domain)
 		if err != nil {
 			return err
 		}

--- a/main.go
+++ b/main.go
@@ -9,7 +9,7 @@ import (
 )
 
 type Schema struct {
-	Target         string `json:"target"`
+	Server         string `json:"dns_server"`
 	Port           int    `json:"port"`
 	Record         string `json:"record"`
 	Domain         string `json:"domain"`


### PR DESCRIPTION
switch `target` to `server` in schema

fix `A` and `AAAA` lookups with appropriate networks

improve `DialContext`

fix overwriting local variables